### PR TITLE
feat: serialize data from request parsing error

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,5 +1,6 @@
 from flask_restx import Api
 from werkzeug.exceptions import HTTPException
+from collections import OrderedDict
 
 from .routes.date_route import api as date
 from .routes.timezones_route import api as timezones
@@ -8,6 +9,19 @@ api = Api(bundle_errors=True)
 
 @api.errorhandler(HTTPException)
 def http_exception_error_handler(error):
+    if hasattr(error, "data"):
+        error.data = OrderedDict([
+            ("code", error.code),
+            ("message", error.data["message"] or "An unexpected error occurred"),
+            ("errors", error.data["errors"]),
+        ])
+
+        return {
+            "code": error.code,
+            "message": error.data["message"] or "An unexpected error occurred",
+            "error": error.data["errors"],
+        }, error.code
+
     return {
         "code": error.code,
         "message": error.description or "An unexpected error occurred",

--- a/src/utils/error_handler.py
+++ b/src/utils/error_handler.py
@@ -27,6 +27,7 @@ class ErrorHandler:
             }
 
         return {
+            "code": 500,
             "message": "An unexpected error occurred",
             "error": str(self.error),
         }, 500


### PR DESCRIPTION
Don't add help to add_argument, just normalize return from RequestParser errors with the others error return.

resolve #19 