### PR TITLE
feat: add health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+RUN apt update && apt install -y curl
 
 COPY . .
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,13 @@ services:
       - "5000:5000"
     depends_on:
       - mongo
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 10s
+      start_interval: 5s
     
 volumes:
   mongo_data:

--- a/src/api.py
+++ b/src/api.py
@@ -1,11 +1,21 @@
-from flask_restx import Api
+from flask_restx import Api, Resource
 from werkzeug.exceptions import HTTPException
 from collections import OrderedDict
 
 from .routes.date_route import api as date
 from .routes.timezones_route import api as timezones
 
-api = Api(bundle_errors=True)
+api = Api(bundle_errors=True, default="Default")
+
+@api.route('/health')
+class Health(Resource):
+    """
+    Base route to validate health
+    Used in the docker as health check
+    """
+    def get(self):
+        "API health validation"
+        return {"status": "ok"}, 200
 
 @api.errorhandler(HTTPException)
 def http_exception_error_handler(error):


### PR DESCRIPTION
## Summary
Adds a `/health` endpoint, configures Docker healthcheck in Compose, and installs curl in the image so the service can be monitored and auto-recovered.

### Changes
| Commit | File | Change |
|--------|------|--------|
| `4eed744` | `Dockerfile` | Installed `curl` so the healthcheck command works inside the container. |
| `b2866fe` | `src/api.py` | Added `Health` resource at `GET /health` returning `{"status": "ok"}` with 200 status. Also set `default="Default"` on the Api instance to satisfy Flask-RESTx conventions. |
| `861f4e1` | `compose.yaml` | Added `healthcheck` block to the `api` service: curl test against `/health`, 90s interval, 30s timeout, 5 retries, 10s start period, 5s start interval. |

### How to Test
```bash
# Health endpoint
curl http://localhost:5000/health
# → {"status": "ok"}
# Docker health status
docker compose ps
# → Name               Service        Status
#    dateend-api-1     api            running (healthy)
```

### Notes
- The /health endpoint intentionally has no DB dependency so it reflects process health, not data-layer health.
