### PR TITLE
refactor: add db consts as env vars

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,9 @@ jobs:
 
     env:
       MONGO_URI: ${{ secrets.MONGO_URI }}
+      TEST_MONGO_URI: ${{ secrets.MONGO_URI }}
       MONGO_DB: ${{ secrets.MONGO_DB }}
+      TEST_DB_NAME: ${{ secrets.MONGO_DB }}
 
     steps:
       - name: Checkout

--- a/test/fixtures/db.py
+++ b/test/fixtures/db.py
@@ -1,14 +1,14 @@
 import pytest
 from werkzeug.test import Client
 from pymongo import MongoClient
-
-TEST_MONGO_URI = 'mongodb://localhost/test'
-TEST_DB_NAME = 'test'
+from dotenv import load_dotenv
+import os
+load_dotenv()
 
 @pytest.fixture
 def collection():
-    mongo = MongoClient(TEST_MONGO_URI)
-    db = mongo[TEST_DB_NAME]
+    mongo = MongoClient(os.getenv("TEST_MONGO_URI"))
+    db = mongo[os.getenv("TEST_DB_NAME")]
     collection = db.dates
 
     yield collection
@@ -20,8 +20,8 @@ def client(collection):
     from app import create_app
     app = create_app()
 
-    app.config["MONGO_URI"] = TEST_MONGO_URI
-    app.config["MONGO_DB"] = TEST_DB_NAME
+    app.config["MONGO_URI"] = os.getenv("TEST_MONGO_URI")
+    app.config["MONGO_DB"] = os.getenv("TEST_DB_NAME")
 
     test_client = Client(app)
 


### PR DESCRIPTION
## Summary
This PR improves test database configuration by introducing environment variables for MongoDB connection details and wiring them into CI.

## Changes

### CI update

#### Adds test DB configuration variables to GitHub Actions:
- `TEST_MONGO_URI: ${{ secrets.MONGO_URI }}`
- `TEST_DB_NAME: ${{ secrets.MONGO_DB }}`

### Refactor test DB initialization
- Loads env vars via dotenv and uses them to initialize the Mongo client:

```python
from dotenv import load_dotenv
import os
load_dotenv()
...
mongo = MongoClient(os.getenv("TEST_MONGO_URI"))
db = mongo[os.getenv("TEST_DB_NAME")]
```

## Why
- Avoids hardcoded DB config in test code
- Makes local + CI environments behave the same
- Improves portability and reduces setup friction

## Checklist
 - [x] Tests pass locally with .env
 - [x] Tests pass in CI with GitHub secrets
 - [x]  No sensitive values committed to repo
 - [x] Removed consts from `tests/fixtures/db.py`